### PR TITLE
Resolve #137 in blueprint-freespeech/ricochet-refresh

### DIFF
--- a/projects/qt/build
+++ b/projects/qt/build
@@ -26,6 +26,9 @@ patch -p1 < $rootdir/fix_deployment_target.patch
 
 # OpenGL patch for macos
 patch -p1 < $rootdir/fix_opengl_linker_error.patch
+
+# Fix the issue where whitespaces get ignored after certain character
+patch -p1 < $rootdir/macos_font_shaping.patch
 [% END -%]
 
 # ./configure -verbose -[% IF c("var/osx") -%]ext[% END -%]prefix "$distdir" -release -opensource -confirm-license -no-shared -static [% IF c("var/windows") %]-static-runtime[% END -%] [% IF !c("var/linux") %]-no-dbus[% END -%] -no-qml-debug -no-glib -no-openssl [% IF c("var/windows") %]-no-opengl[% END -%] -no-fontconfig -no-icu -qt-pcre -qt-zlib -qt-libpng -qt-libjpeg [% IF c("var/linux") %]-no-opengl[% END -%] -nomake tools -nomake examples -nomake tests -xplatform [% c('var/xplatform') %] -device-option CROSS_COMPILE=[% c('var/cross_compile') %] -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtlocation -skip qtlottie [% IF !c("var/osx") -%]-skip qtmacextras[% END -%] -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview [% IF !c("var/windows") %]-skip qtwinextras[% END -%] [% IF !c("var/linux") %]-skip qtx11extras[% END -%] -skip qtxmlpatterns [% IF c("var/linux") %]-xkbcommon -bundled-xcb-xinput[% END -%] [% IF c("var/osx") -%]-I $cppincludes -sysroot $sysrootdir [% END -%]

--- a/projects/qt/config
+++ b/projects/qt/config
@@ -80,3 +80,5 @@ input_files:
    enable: '[% c("var/osx") %]'
  - filename: fix_opengl_linker_error.patch
    enable: '[% c("var/osx") %]'
+ - filename: macos_font_shaping.patch
+   enable: '[% c("var/osx") %]'

--- a/projects/qt/macos_font_shaping.patch
+++ b/projects/qt/macos_font_shaping.patch
@@ -1,0 +1,64 @@
+From 6d306a0e3755258beb11d7f488c2bb1bf66bec19 Mon Sep 17 00:00:00 2001
+From: Eskil Abrahamsen Blomfeldt <eskil.abrahamsen-blomfeldt@qt.io>
+Date: Tue, 17 Nov 2020 09:23:39 +0100
+Subject: [PATCH] Fix shaping problems on iOS 14 / macOS 11
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Detection of AAT fonts was exclusively based on the existence
+of tables mort, morx and kerx. In the SF font (the UI default)
+on iOS 14 and Big Sur, none of these tables actually exist, so
+we would accidentally use the OpenType shaper for it. But there
+are plenty of other AAT tables in the font and the OT shaper
+can't handle it. In particular, this caused us to get the wrong
+advance for comma when it was followed by a space.
+
+Looking at all the affected SF fonts on Big Sur, they all have
+the trak table, so we expand the detection to include this.
+This is possibly also the table used to determine the correct
+glyph positions in this case.
+
+In Qt 6, this already works as expected, because Harfbuzz has
+built-in support for AAT and does not require the CoreText
+fallback. Therefore, this is just a hotfix for the 5.15 series
+and there is no need to upstream this patch.
+
+[ChangeLog][macOS] Fixed shaping of default UI font on macOS 11
+and iOS 14.
+
+Fixes: QTBUG-88495
+Change-Id: Ia2b3f45cbc0c32b93864760cb427ede6b0566e8f
+Reviewed-by: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+---
+ qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc | 2 +-
+ qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.h  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc b/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
+index d64cb7edbd8..11b6deee045 100644
+--- a/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
++++ b/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.cc
+@@ -1322,7 +1322,7 @@ struct hb_coretext_aat_shaper_face_data_t {};
+ hb_coretext_aat_shaper_face_data_t *
+ _hb_coretext_aat_shaper_face_data_create (hb_face_t *face)
+ {
+-  static const hb_tag_t tags[] = {HB_CORETEXT_TAG_MORX, HB_CORETEXT_TAG_MORT, HB_CORETEXT_TAG_KERX};
++  static const hb_tag_t tags[] = {HB_CORETEXT_TAG_MORX, HB_CORETEXT_TAG_MORT, HB_CORETEXT_TAG_KERX, HB_CORETEXT_TAG_TRAK};
+ 
+   for (unsigned int i = 0; i < ARRAY_LENGTH (tags); i++)
+   {
+diff --git a/src/3rdparty/harfbuzz-ng/src/hb-coretext.h b/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
+index 4b0a6f01b6f..12f7d2515bd 100644
+--- a/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
++++ b/qtbase/src/3rdparty/harfbuzz-ng/src/hb-coretext.h
+@@ -43,7 +43,7 @@ HB_BEGIN_DECLS
+ #define HB_CORETEXT_TAG_MORT HB_TAG('m','o','r','t')
+ #define HB_CORETEXT_TAG_MORX HB_TAG('m','o','r','x')
+ #define HB_CORETEXT_TAG_KERX HB_TAG('k','e','r','x')
+-
++#define HB_CORETEXT_TAG_TRAK HB_TAG('t','r','a','k')
+ 
+ HB_EXTERN hb_face_t *
+ hb_coretext_face_create (CGFontRef cg_font);


### PR DESCRIPTION
Brings in the patch from https://github.com/qt/qtbase/commit/6d306a0e3755258beb11d7f488c2bb1bf66bec19 that resolves HarfBuzz not having support for AAT fonts, causing [this issue](https://github.com/blueprint-freespeech/ricochet-refresh/issues/137).