### PR TITLE
package: use dd instead of sed to patch linuxdeploy

### DIFF
--- a/projects/package/build
+++ b/projects/package/build
@@ -137,7 +137,8 @@ pushd appimage
 linuxdeploy="$rootdir/[% c('input_files_by_name/linuxdeploy') %]"
 chmod +x $linuxdeploy
 # https://github.com/AppImage/AppImageKit/issues/1027#issuecomment-641601097
-sed 's|AI\x02|\x00\x00\x00|g' -i $linuxdeploy
+# https://github.com/linuxdeploy/linuxdeploy/issues/154#issuecomment-741936850
+dd if=/dev/zero of=$linuxdeploy conv=notrunc bs=1 count=3 seek=8
 
 mkdir -p AppDir/usr/bin
 cp -a $distdir/ricochet-refresh/* AppDir/usr/bin/.


### PR DESCRIPTION
If `$linuxdeploy` contains the sequence `AI\x02` more than once, `sed` will replace all its occurrences. Instead, it should only replace the first one. This can be achieved either using one of `sed`'s flags/options, or using

> the much more precise and determinstic `dd`

as suggested [by the intial author of the patch themselves](https://github.com/linuxdeploy/linuxdeploy/issues/154#issuecomment-741936850).

For the record, this is not just a theoretical concern: [`linuxdeploy` for `linux-aarch64`](https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20231206-1/linuxdeploy-aarch64.AppImage) (at least the linked version) does indeed contain the sequence `AI\x02` twice, and the erroneous replacement of the second one makes the command

```sh
$linuxdeploy --appimage-extract-and-run -d ./ricochet-refresh.desktop  ${ICON_ARGS} --icon-filename=ricochet-refresh --output appimage --appdir AppDir
```

fail.