### PR TITLE
ricochet-refresh: export SOURCE_DATE_EPOCH

### DIFF
--- a/projects/linuxdeploy/build
+++ b/projects/linuxdeploy/build
@@ -1,0 +1,30 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+
+# Define a wrapper script to remove the '-mkfs-time 0' argument
+# from linuxdeploy's internal mksquashfs command-line (it conflicts
+# with SOURCE_DATE_EPOCH and obstructs reproducible builds)
+# See https://github.com/AppImage/AppImageKit/issues/929#issuecomment-926001098
+# Adapted from https://github.com/spesmilo/electrum/blob/9c94eb99f80fba89973978dd7f6d4727818ad7a3/contrib/build-linux/appimage/make_appimage.sh
+linuxdeploy=./linuxdeploy-[% c("var/appimage_arch") %].AppImage
+chmod +x $linuxdeploy
+$linuxdeploy --appimage-extract
+rm -d $projdir
+mv squashfs-root $projdir
+
+MKSQUASHFS=$projdir/plugins/linuxdeploy-plugin-appimage/appimagetool-prefix/usr/lib/appimagekit/mksquashfs
+mv $MKSQUASHFS ${MKSQUASHFS}_orig
+# Paths are hardcoded, not relative. linuxdeploy must be executed
+# from $projdir.
+cat <<EOF >$MKSQUASHFS
+#!/bin/sh
+args=\$(echo "\$@" | sed -e 's/-mkfs-time 0//')
+${MKSQUASHFS}_orig \$args
+EOF
+chmod +x $MKSQUASHFS
+
+cd $distdir
+[% c('tar', {
+        tar_src => [ project ],
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+    }) %]

--- a/projects/linuxdeploy/config
+++ b/projects/linuxdeploy/config
@@ -1,0 +1,29 @@
+filename: '[% project %]-[% c("version") %]-[% c("var/arch") %]-[% c("var/build_id") %].tar.gz'
+version: '[% c("var/versions/linuxdeploy") %]'
+container:
+  use_container: 1
+
+var:
+  linux_cross: 1
+
+targets:
+  linux-x86_64:
+    var:
+      appimage_arch: x86_64
+  linux-i686:
+    var:
+      appimage_arch: i386
+      arch_deps:
+        - zlib1g:i386
+
+
+input_files:
+ - project: container-image
+ - name: linuxdeploy
+   enable: '[% c("var/linux-i686") %]'
+   URL: https://github.com/linuxdeploy/linuxdeploy/releases/download/[% c("version") %]/linuxdeploy-[% c("var/appimage_arch") %].AppImage
+   sha256sum: bca5ad35204f06a6ca5930aa1c5cceec7978ffc2c26bf16dc05ed91587488bbb
+ - name: linuxdeploy
+   enable: '[% c("var/linux-x86_64") %]'
+   URL: https://github.com/linuxdeploy/linuxdeploy/releases/download/[% c("version") %]/linuxdeploy-[% c("var/appimage_arch") %].AppImage
+   sha256sum: c242e21f573532c03adc2c356b70055ee0de2ae66e235d086b714e69d2cae529

--- a/projects/package/build
+++ b/projects/package/build
@@ -8,6 +8,8 @@ set +x
 VERSION=[% c("version") %]
 ARCH=[% c("var/arch") %]
 
+export SOURCE_DATE_EPOCH='[% c("timestamp") %]'
+
 #
 # Windows packaging
 #
@@ -132,13 +134,11 @@ popd # deb
 # build appimage
 #
 APPIMAGEARCH=[% c("var/appimage_arch") %]
+tar -C $distdir -xf [% c('input_files_by_name/linuxdeploy') %]
+linuxdeploy=$distdir/linuxdeploy/AppRun
+
 mkdir appimage
 pushd appimage
-linuxdeploy="$rootdir/[% c('input_files_by_name/linuxdeploy') %]"
-chmod +x $linuxdeploy
-# https://github.com/AppImage/AppImageKit/issues/1027#issuecomment-641601097
-# https://github.com/linuxdeploy/linuxdeploy/issues/154#issuecomment-741936850
-dd if=/dev/zero of=$linuxdeploy conv=notrunc bs=1 count=3 seek=8
 
 mkdir -p AppDir/usr/bin
 cp -a $distdir/ricochet-refresh/* AppDir/usr/bin/.
@@ -160,7 +160,7 @@ cat > ricochet-refresh.desktop << EOF
 EOF
 
 # build .appimage
-$linuxdeploy --appimage-extract-and-run -d ./ricochet-refresh.desktop  ${ICON_ARGS} --icon-filename=ricochet-refresh --output appimage --appdir AppDir
+$linuxdeploy -d ./ricochet-refresh.desktop  ${ICON_ARGS} --icon-filename=ricochet-refresh --output appimage --appdir AppDir
 
 mv Ricochet-Refresh-*${APPIMAGEARCH}.AppImage $projdir/ricochet-refresh-${VERSION}-${APPIMAGEARCH}.appimage
 

--- a/projects/package/config
+++ b/projects/package/config
@@ -79,14 +79,9 @@ input_files:
    # linux packaging
  - filename: linux
    enable: '[% c("var/linux") %]'
- - name: linuxdeploy
-   enable: '[% c("var/linux-i686") %]'
-   URL: https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20231026-1/linuxdeploy-i386.AppImage
-   sha256sum: bca5ad35204f06a6ca5930aa1c5cceec7978ffc2c26bf16dc05ed91587488bbb
- - name: linuxdeploy
-   enable: '[% c("var/linux-x86_64") %]'
-   URL: https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20231026-1/linuxdeploy-x86_64.AppImage
-   sha256sum: c242e21f573532c03adc2c356b70055ee0de2ae66e235d086b714e69d2cae529
+ - project: linuxdeploy
+   name: linuxdeploy
+   enable: '[% c("var/linux") %]'
    # windows packaging
  - filename: windows
    enable: '[% c("var/windows") %]'

--- a/projects/ricochet-refresh/build
+++ b/projects/ricochet-refresh/build
@@ -136,6 +136,7 @@ CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=MinSizeRel
 [% END -%]
 
 mkdir build && cd build
+export SOURCE_DATE_EPOCH='[% c("timestamp") %]'
 RICOCHET_REFRESH_VERSION=[% c('version') %] cmake -S ../src $CMAKE_FLAGS
 
 cmake --build . -j[% c('num_procs') %]

--- a/rbm.conf
+++ b/rbm.conf
@@ -73,6 +73,7 @@ var:
     nsis: '3.09'
     rust: 1.74.0
     rcodesign: 0.22.0
+    linuxdeploy: 1-alpha-20231026-1
 
 targets:
   # Release channels


### PR DESCRIPTION
This PR should be enough to make the `linux-{i686,x86_64}` deb package and tar.gz archive reproducible. The AppImages and bundles for other platforms are not. `stable` sha256sums:

```
2343c708d43bc11038cbc1cf6cbd2445cfcebe8efe91ecf0838da12de1832d50  ricochet-refresh-3.0.22-i386.appimage
005146aebc2a65ed45d6c71325a77b9806a6dd9c2b4c19bb2efe1b1d9dc124b7  ricochet-refresh-3.0.22-linux-i686.tar.gz
3bd29d896a9e2b05581614022bcfa9272618dc60990da01509d362f66bb9fb9e  ricochet-refresh-3.0.22-linux-x86_64.tar.gz
44d388c029c7f8729c438da6d22c00fc5c634618dbfa58e4f63ee1bddd941a51  ricochet-refresh-3.0.22-macos-aarch64.dmg
a1220cda56f243b190594913fede996151aac245a97e12bb002c8960cec6c7a1  ricochet-refresh-3.0.22-macos-x86_64.dmg
7a4962b67f52df8b9b018fecf54a35aa85b49b6cf8af4de306784395bc251ac7  ricochet-refresh-3.0.22-windows-i686-installer.exe
443dc1344de3d9961c532061abbe6744a49b009bda6fed8d0fb45312b9afb99f  ricochet-refresh-3.0.22-windows-i686.zip
c24cca0abf68449b0775156d9f1d48cc411d8e8e23635a1e55649762534ca7e0  ricochet-refresh-3.0.22-windows-x86_64-installer.exe
b84818e995af58a2cc0e8f19684ea2ff53e060f8389d41a8b225e66a4aee5a98  ricochet-refresh-3.0.22-windows-x86_64.zip
06fa7a0d67f8624345d81fe37d75a1ccdf4880a2ee68357801b467593652459e  ricochet-refresh-3.0.22-x86_64.appimage
4a4904fe69c2112c486e8d9f4a26c4b1a99f935436b212ac81b54c81d5d7b68f  ricochet-refresh_3.0.22_amd64.deb
4e33b665be152a000e523e5195a236246c1233de42968f0c94ead9faf61ee7c2  ricochet-refresh_3.0.22_i386.deb
```