### PR TITLE
Ricochet Refresh for linux-aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ ricochet-linux-i686-stable: submodule-update
 ricochet-linux-x86_64-stable: submodule-update
 	$(rbm) build package --target linux --target linux-x86_64 --target stable
 
+ricochet-linux-aarch64-stable: submodule-update
+	$(rbm) build package --target linux-cross --target linux --target linux-aarch64 --target stable
+
 ricochet-macos-stable:
 	$(MAKE) ricochet-macos-x86_64-stable
 	$(MAKE)  ricochet-macos-aarch64-stable
@@ -66,6 +69,9 @@ ricochet-linux-i686-alpha: submodule-update
 ricochet-linux-x86_64-alpha: submodule-update
 	$(rbm) build package --target linux --target linux-x86_64 --target alpha
 
+ricochet-linux-aarch64-alpha: submodule-update
+	$(rbm) build package --target linux-cross --target linux --target linux-aarch64 --target alpha
+
 ricochet-macos-alpha:
 	$(MAKE) ricochet-macos-x86_64-alpha
 	$(MAKE) ricochet-macos-aarch64-alpha
@@ -97,12 +103,16 @@ ricochet-release-alpha-sign: submodule-update
 ricochet-linux-testbuild:
 	$(MAKE) ricochet-linux-i686-testbuild
 	$(MAKE) ricochet-linux-x86_64-testbuild
+	$(MAKE) ricochet-linux-aarch64-testbuild
 
 ricochet-linux-i686-testbuild: submodule-update
 	$(rbm) build package --target linux --target linux-i686 --target testbuild
 
 ricochet-linux-x86_64-testbuild: submodule-update
 	$(rbm) build package --target linux --target linux-x86_64 --target testbuild
+
+ricochet-linux-aarch64-testbuild: submodule-update
+	$(rbm) build package --target linux-cross --target linux --target linux-aarch64 --target testbuild
 
 ricochet-macos-testbuild:
 	$(MAKE) ricochet-macos-x86_64-testbuild

--- a/projects/binutils/build
+++ b/projects/binutils/build
@@ -4,6 +4,11 @@
 tar -C $builddir -xf [% project %]-[% c('version') %].tar.xz
 cd $builddir/[% project %]-[% c('version') %]
 
+[% IF c("var/linux-cross") -%]
+  projdir=$projdir-cross-[% c("var/arch") %]
+  mkdir -p $projdir
+[% END -%]
+
 ./configure --prefix=$projdir --disable-shared --enable-static \
         --target=[% c("var/compiler_target") %] --disable-multilib \
         --enable-lto --disable-gdb --enable-deterministic-archives
@@ -13,6 +18,6 @@ make install
 
 cd $distdir
 [% c('tar', {
-        tar_src => [ project ],
+        tar_src => [ c('var/distdir') ],
         tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
         }) %]

--- a/projects/binutils/config
+++ b/projects/binutils/config
@@ -5,6 +5,7 @@ container:
   use_container: 1
 
 var:
+  distdir: binutils
   deps:
     - bison
     - texinfo
@@ -13,6 +14,10 @@ targets:
   windows:
     var:
       configure_opt: '--disable-shared --enable-static --target=[% c("var/arch") %]-w64-mingw32 --disable-multilib --enable-lto --disable-gdb --enable-deterministic-archives'
+
+  linux-cross:
+    var:
+      distdir: 'binutils-cross-[% c("var/arch") %]'
 
 input_files:
   - project: container-image

--- a/projects/gcc-cross/build
+++ b/projects/gcc-cross/build
@@ -1,0 +1,87 @@
+#!/bin/sh
+[% c("var/set_default_env") -%]
+
+# Rename projdir so we don't distinguish between gcc and gcc-cross
+projdir=$distdir/gcc
+
+# Install native gcc
+cd $distdir
+tar xf $rootdir/[% c('input_files_by_name/gcc-native') %]
+export PATH="$projdir/bin:$PATH"
+
+# Install cross binutils (needed for cross-compiling)
+cd $distdir
+tar xf $rootdir/[% c('input_files_by_name/binutils') %]
+rsync -a binutils-cross-[% c("var/arch") %]/* $projdir
+rm -rf binutils-cross-[% c("var/arch") %]
+
+# Install Linux headers, see Step 2 of
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+# Doing this before gcc configure is intended to solve a limits.h issue
+cd $builddir
+mkdir linux
+cd linux
+tar -xJf $rootdir/linux-[% c("var/linux_version") %].tar.xz
+cd linux-[% c("var/linux_version") %]
+make ARCH=[% IF c("var/arch") == "aarch64" %]arm64[% ELSE %][% c("var/arch") %][% END %] INSTALL_HDR_PATH=$projdir/[% c("var/compiler_target") %] headers_install
+
+cd $projdir
+tar -xJf $rootdir/[% c('input_files_by_name/gcc') %]
+cd gcc-[% c("version") %]
+patch -p1 <$rootdir/gcc-cross.patch
+
+cd $projdir
+gcc-[% c("version") %]/configure --prefix=$projdir --includedir=$projdir/[% c("var/compiler_target") %]/include [% c("var/configure_opt") %]
+
+# For cross-compiling to work, we need to partially build GCC, then build
+# glibc, then come back to finish GCC.
+
+# Build only the components of GCC that don't need glibc, see Step 3 of
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+cd $projdir
+make -j[% c("num_procs") %] all-gcc
+make install-gcc
+
+# Build glibc headers and startup files, see Step 4 of
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+cd $builddir
+mkdir glibc
+cd glibc
+tar -xJf $rootdir/glibc-[% c("var/glibc_version") %].tar.xz
+
+# TODO: Remove --disable-werror once glibc is upgraded to a version that's
+# designed to work with the GCC version we're using.
+glibc-[% c("var/glibc_version") %]/configure --prefix=$projdir/[% c("var/compiler_target") %] --build=$MACHTYPE --host=[% c("var/compiler_target") %] --target=[% c("var/compiler_target") %] --with-headers=$projdir/[% c("var/compiler_target") %]/include --disable-multilib --disable-werror libc_cv_forced_unwind=yes
+make install-bootstrap-headers=yes install-headers
+make -j[% c("num_procs") %] csu/subdir_lib
+install csu/crt1.o csu/crti.o csu/crtn.o $projdir/[% c("var/compiler_target") %]/lib
+[% c("var/compiler_target") %]-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o $projdir/[% c("var/compiler_target") %]/lib/libc.so
+# stdio_lim.h is intended to solve a limits.h issue
+touch $projdir/[% c("var/compiler_target") %]/include/gnu/stubs.h $projdir/[% c("var/compiler_target") %]/include/bits/stdio_lim.h
+
+# Build compiler support library, see Step 5 of
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+cd $projdir
+make -j[% c("num_procs") %] all-target-libgcc
+make install-target-libgcc
+
+# finish building glibc, see Step 6 of
+# https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/
+cd $builddir/glibc
+make -j[% c("num_procs") %]
+make install
+
+# We're done with glibc, we can now finish building gcc...
+cd $projdir
+make -j[% c("num_procs") %]
+make install
+
+# Include a working version of limits.h
+cd gcc-[% c("version") %]
+cat gcc/limitx.h gcc/glimits.h gcc/limity.h >$projdir/lib/gcc/[% c("var/compiler_target") %]/[% c("version") %]/include/limits.h
+
+cd $distdir
+[% c('tar', {
+        tar_src => [ c('var/distdir') ],
+        tar_args => '-caf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/gcc-cross/config
+++ b/projects/gcc-cross/config
@@ -1,0 +1,38 @@
+# vim: filetype=yaml sw=2
+filename: '[% project %]-[% c("version") %]-[% c("var/arch") %]-[% c("var/build_id") %].tar.[% c("compress_tar") %]'
+version: '[% pc("gcc-source", "version") %]'
+container:
+  use_container: 1
+hardened_gcc: 1
+var:
+  distdir: gcc
+  deps:
+    - build-essential
+    - libmpc-dev
+    - gawk
+    - rsync
+    - python3
+    - bison
+  configure_opt: '--target=[% c("var/compiler_target") %] --disable-multilib --enable-languages=c,c++ --with-glibc-version=[% c("var/glibc_version") %]'
+  glibc_version: '[% c("var/versions/glibc") %]'
+  linux_version: '[% c("var/versions/linux") %]'
+
+input_files:
+  - project: container-image
+  - project: gcc-source
+    name: gcc
+    target_replace:
+      '^linux-.*': linux-x86_64
+  - name: binutils
+    project: binutils
+    target_prepend:
+      - linux-cross
+  - name: gcc-native
+    project: gcc
+    target_replace:
+      '^linux-.*': linux-x86_64
+  - URL: 'https://ftp.gnu.org/gnu/glibc/glibc-[% c("var/glibc_version") %].tar.xz'
+    sha256sum: 9246fe44f68feeec8c666bb87973d590ce0137cca145df014c72ec95be9ffd17
+  - URL: 'https://www.kernel.org/pub/linux/kernel/v5.x/linux-[% c("var/linux_version") %].tar.xz'
+    sha256sum: e310588c4b23f0959614e60f007afc20e9b1a8f296d682b041fa129f96fbe151
+  - filename: "gcc-cross.patch"

--- a/projects/gcc-cross/gcc-cross.patch
+++ b/projects/gcc-cross/gcc-cross.patch
@@ -1,0 +1,18 @@
+Avoids "../../../gcc-10.3.0/libsanitizer/asan/asan_linux.cpp:217:21: error:
+'PATH_MAX' was not declared in this scope". PATH_MAX is in /include/linux/limits.h,
+which is usually included by /include/limits.h (indirectly, through posix headers,
+etc.). For some reason, when cross-compiling, this inclusion chain is broken and
+we must include <linux/limits.h> by hand.
+
+Index: gcc-10.3.0/libsanitizer/asan/asan_linux.cpp
+===================================================================
+--- gcc-10.3.0.orig/libsanitizer/asan/asan_linux.cpp
++++ gcc-10.3.0/libsanitizer/asan/asan_linux.cpp
+@@ -32,6 +32,7 @@
+ #include <dlfcn.h>
+ #include <fcntl.h>
+ #include <limits.h>
++#include <linux/limits.h>
+ #include <pthread.h>
+ #include <stdio.h>
+ #include <unistd.h>

--- a/projects/openssl/config
+++ b/projects/openssl/config
@@ -14,6 +14,9 @@ targets:
   linux-i686:
     var:
       configure_opts: linux-x86 no-shared
+  linux-aarch64:
+    var:
+      configure_opts: linux-aarch64 no-shared enable-ec_nistp_64_gcc_128
   windows-x86_64:
     var:
       configure_opts: 'mingw64 no-shared enable-capieng --cross-compile-prefix=x86_64-w64-mingw32-'

--- a/projects/package/build
+++ b/projects/package/build
@@ -130,6 +130,7 @@ mv ricochet-refresh_${VERSION}_${DEBARCH}.deb $projdir/.
 
 popd # deb
 
+[% IF ! c("var/linux-cross") -%]
 #
 # build appimage
 #
@@ -177,6 +178,7 @@ rm /var/tmp/rbm
 mv Ricochet-Refresh-*${APPIMAGEARCH}.AppImage $projdir/ricochet-refresh-${VERSION}-${APPIMAGEARCH}.appimage
 
 popd # appimage
+[% END -%]
 
 #
 # portable tar.gz

--- a/projects/package/config
+++ b/projects/package/config
@@ -58,6 +58,35 @@ targets:
         - libxext6
         - libxkbcommon0
         - libxkbcommon-x11-0
+  linux-aarch64:
+    var:
+      deb_arch: arm64
+      appimage_arch: aarch64
+      arch_deps:
+        - libfontconfig1-dev:arm64
+        - libfreetype6-dev:arm64
+        - libxkbcommon-dev:arm64
+        - libxcb-glx0-dev:arm64
+        - libxcb-keysyms1-dev:arm64
+        - libxcb-image0-dev:arm64
+        - libxcb-shm0-dev:arm64
+        - libxcb-icccm4-dev:arm64
+        - libxcb-sync0-dev:arm64
+        - libxcb-xfixes0-dev:arm64
+        - libxcb-shape0-dev:arm64
+        - libxcb-randr0-dev:arm64
+        - libxcb-render-util0-dev:arm64
+        - libxcb-xinerama0-dev:arm64
+        - libx11-xcb-dev:arm64
+        - libglu1-mesa-dev:arm64
+        - libxrender-dev:arm64
+        - libxi-dev:arm64
+        - libxkbcommon-x11-dev:arm64
+        - libc6-dev:arm64
+        # linked to by libxdmcp, which is linked by libxcb
+        - libbsd-dev:arm64
+        # linked to by libxcb-image
+        - libxcb-util-dev:arm64
   macos:
     var:
       deps:
@@ -81,7 +110,7 @@ input_files:
    enable: '[% c("var/linux") %]'
  - project: linuxdeploy
    name: linuxdeploy
-   enable: '[% c("var/linux") %]'
+   enable: '[% c("var/linux") && ! c("var/linux-cross") %]'
    # windows packaging
  - filename: windows
    enable: '[% c("var/windows") %]'

--- a/projects/protobuf/build
+++ b/projects/protobuf/build
@@ -17,6 +17,9 @@ mkdir build && cd build
 # compilers are specified through envvars
 CMAKE_FLAGS='-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='$projdir' -Dprotobuf_WITH_ZLIB=OFF -Dprotobuf_BUILD_SHARED_LIBRARIES=OFF -Dprotobuf_BUILD_TESTS=OFF'
 
+[% IF c("var/linux-cross") -%]
+    CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=[% c("var/arch") %] $CMAKE_FLAGS"
+[% END -%]
 [% IF c("var/windows-i686") -%]
     CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=i386 $CMAKE_FLAGS"
 [% END -%]

--- a/projects/qt/build
+++ b/projects/qt/build
@@ -21,6 +21,22 @@ cd $builddir/qt-everywhere-src-[% c('version') %]
   sed -i "s/lib64/lib\/x86_64-linux-gnu/g" qtbase/mkspecs/linux-g++-64/qmake.conf
 [% END -%]
 
+[% IF c("var/linux-cross") %]
+  # The configure script disables pkg-config when cross-compiling if
+  # PKG_CONFIG_LIBDIR and PKG_CONFIG_SYSROOT_DIR are not defined
+  export PKG_CONFIG_LIBDIR="/usr/lib/[% c("var/compiler_target") %]/pkgconfig:/usr/share/pkgconfig"
+  export PKG_CONFIG_SYSROOT_DIR=/
+  # The linker fails to find some indirect dependencies: patch qt so
+  # it knows exactly what it must link to
+  patch -p1 < $rootdir/linux_cross_dependencies.patch
+  # We don't want to include /usr/include's native headers, so we
+  # create symlinks to the required headers instead
+  cppincludes=$distdir/gcc/include
+  for hdir in fontconfig xcb xkbcommon X11; do
+    ln -s "/usr/include/$hdir" "$cppincludes/$hdir"
+  done
+[% END -%]
+
 [% IF c("var/windows") -%]
   # remove d3d12 support (or else build looks for fxc.exe for shader compilation which we do not have)
   sed -i 's/qtConfig(d3d12): SUBDIRS += d3d12//' qtdeclarative/src/plugins/scenegraph/scenegraph.pro
@@ -47,7 +63,7 @@ cd $builddir/qt-everywhere-src-[% c('version') %]
 
 ./configure \
   -prefix "$projdir" \
-  [% IF c("var/macos") -%]-I $cppincludes [% END -%] \
+  [% IF c("var/macos") || c("var/linux-cross") -%]-I $cppincludes [% END -%] \
   -xplatform [% c('var/xplatform') %] \
   -device-option CROSS_COMPILE=[% c('var/cross_compile') %] \
   -release \

--- a/projects/qt/config
+++ b/projects/qt/config
@@ -57,6 +57,35 @@ targets:
         - libxi-dev
         - libxkbcommon-x11-dev
         - libc6-dev
+  linux-aarch64:
+    var:
+      xplatform: linux-aarch64-gnu-g++
+      cross_compile: '$distdir/gcc/bin/aarch64-linux-gnu-'
+      deps:
+        - libfontconfig1-dev:arm64
+        - libfreetype6-dev:arm64
+        - libxkbcommon-dev:arm64
+        - libxcb-glx0-dev:arm64
+        - libxcb-keysyms1-dev:arm64
+        - libxcb-image0-dev:arm64
+        - libxcb-shm0-dev:arm64
+        - libxcb-icccm4-dev:arm64
+        - libxcb-sync0-dev:arm64
+        - libxcb-xfixes0-dev:arm64
+        - libxcb-shape0-dev:arm64
+        - libxcb-randr0-dev:arm64
+        - libxcb-render-util0-dev:arm64
+        - libxcb-xinerama0-dev:arm64
+        - libx11-xcb-dev:arm64
+        - libglu1-mesa-dev:arm64
+        - libxrender-dev:arm64
+        - libxi-dev:arm64
+        - libxkbcommon-x11-dev:arm64
+        - libc6-dev:arm64
+        # linked to by libxdmcp, which is linked by libxcb
+        - libbsd-dev:arm64
+        # linked to by libxcb-image
+        - libxcb-util-dev:arm64
   windows:
     var:
       xplatform: win32-clang-g++
@@ -76,6 +105,8 @@ input_files:
    sha256sum: efa99827027782974356aceff8a52bd3d2a8a93a54dd0db4cca41b5e35f1041c
  - filename: fix_climits.patch
    enable: '[% c("var/linux") %]'
+ - filename: linux_cross_dependencies.patch
+   enable: '[% c("var/linux-cross") %]'
  - filename: fix_hardcode_xcode_paths.patch
    enable: '[% c("var/macos") %]'
  - filename: fix_deployment_target.patch

--- a/projects/qt/linux_cross_dependencies.patch
+++ b/projects/qt/linux_cross_dependencies.patch
@@ -1,0 +1,191 @@
+Add dependencies for cross-compilation
+
+Index: qt-everywhere-src-5.15.13/qtbase/src/gui/configure.json
+===================================================================
+--- qt-everywhere-src-5.15.13.orig/qtbase/src/gui/configure.json
++++ qt-everywhere-src-5.15.13/qtbase/src/gui/configure.json
+@@ -64,6 +64,16 @@
+                 { "type": "makeSpec", "spec": "BCM_HOST" }
+             ]
+         },
++        "brotli": {
++            "sources": [
++                "-lbrotlidec -lbrotlicommon"
++            ]
++        },
++        "dl": {
++            "sources": [
++                "-ldl"
++            ]
++        },
+         "dxguid": {
+             "label": "DirectX GUID",
+             "sources": [
+@@ -244,7 +254,16 @@
+                 { "libs": "-lfreetype" }
+             ],
+             "use": [
+-                { "lib": "zlib", "condition": "features.system-zlib" }
++                { "lib": "zlib", "condition": "features.system-zlib" },
++                { "lib": "libm" },
++                { "lib": "libpng" },
++                { "lib": "brotli" },
++                { "lib": "libz" }
++            ]
++        },
++        "expat": {
++            "sources": [
++                "-lexpat"
+             ]
+         },
+         "fontconfig": {
+@@ -264,7 +283,7 @@
+                 { "type": "pkgConfig", "args": "fontconfig" },
+                 { "type": "freetype", "libs": "-lfontconfig" }
+             ],
+-            "use": "freetype"
++            "use": "freetype expat uuid pthread"
+         },
+         "gbm": {
+             "label": "GBM",
+@@ -327,6 +346,12 @@
+                 "-llgmon"
+             ]
+         },
++        "libbsd": {
++            "sources": [
++                { "type": "pkgConfig", "args": "libbsd" }
++            ],
++            "use": "dl libmd"
++        },
+         "libinput": {
+             "label": "libinput",
+             "test": {
+@@ -378,6 +403,16 @@
+                 "-ljpeg"
+             ]
+         },
++        "libm": {
++            "sources": [
++                "-lm"
++            ]
++        },
++        "libmd": {
++            "sources": [
++                { "type": "pkgConfig", "args": "libmd" }
++            ]
++        },
+         "libmd4c": {
+             "label": "libmd4c",
+             "test": {
+@@ -407,6 +442,11 @@
+                 { "lib": "zlib", "condition": "features.system-zlib" }
+             ]
+         },
++        "libz": {
++            "sources": [
++                "-lz"
++            ]
++        },
+         "mtdev": {
+             "label": "mtdev",
+             "test": {
+@@ -486,6 +526,11 @@
+                 { "type": "makeSpec", "spec": "OPENVG" }
+             ]
+         },
++        "pthread": {
++            "sources": [
++                "-lpthread"
++            ]
++        },
+         "tslib": {
+             "label": "tslib",
+             "test": {
+@@ -496,6 +541,11 @@
+                 "-lts"
+             ]
+         },
++        "uuid": {
++            "sources": [
++                "-luuid"
++            ]
++        },
+         "v4l2": {
+             "label": "V4L2",
+             "test": {
+@@ -553,6 +603,19 @@
+                 { "type": "pkgConfig", "args": "wayland-server" }
+             ]
+         },
++        "Xau": {
++            "label": "Xau",
++            "sources": [
++                { "type": "pkgConfig", "args": "xau" }
++            ]
++        },
++        "Xdmcp": {
++            "label": "Xdmcp",
++            "sources": [
++                { "type": "pkgConfig", "args": "xdmcp" }
++            ],
++            "use": "libbsd"
++        },
+         "xlib": {
+             "label": "XLib",
+             "test": {
+@@ -563,8 +626,10 @@
+             },
+             "headers": "X11/Xlib.h",
+             "sources": [
++                { "type": "pkgConfig", "args": "x11" },
+                 { "type": "makeSpec", "spec": "X11" }
+-            ]
++            ],
++            "use": "xcb dl"
+         },
+         "x11sm": {
+             "label": "X11 session management",
+@@ -590,7 +655,8 @@
+             "sources": [
+                 { "type": "pkgConfig", "args": "xcb >= 1.11" },
+                 "-lxcb"
+-            ]
++            ],
++            "use": "Xau Xdmcp"
+         },
+         "xcb_icccm": {
+             "label": "XCB ICCCM >= 0.3.9",
+@@ -608,7 +674,7 @@
+                 { "type": "pkgConfig", "args": "xcb-image >= 0.3.9" },
+                 "-lxcb-image"
+             ],
+-            "use": "xcb_shm xcb"
++            "use": "xcb_shm xcb_util xcb"
+         },
+         "xcb_keysyms": {
+             "label": "XCB Keysyms >= 0.3.9",
+@@ -682,6 +748,13 @@
+             ],
+             "use": "xcb"
+         },
++        "xcb_util": {
++            "label": "XCB Util",
++            "sources": [
++                "-lxcb-util"
++            ],
++            "use": "xcb"
++        },
+         "xcb_xlib": {
+             "label": "XCB Xlib",
+             "test": {
+@@ -768,7 +841,8 @@
+             "sources": [
+                 { "type": "pkgConfig", "args": "xkbcommon-x11" },
+                 "-lxkbcommon -lxkbcommon-x11"
+-            ]
++            ],
++            "use": "xcb xcb_xkb"
+         },
+         "xrender": {
+             "label": "XRender for native painting",

--- a/projects/release/build
+++ b/projects/release/build
@@ -5,6 +5,7 @@
 
 cp [% c('input_files_by_name/linux-i686') %]/* [% dest_dir %]/.
 cp [% c('input_files_by_name/linux-x86_64') %]/* [% dest_dir %]/.
+cp [% c('input_files_by_name/linux-aarch64') %]/* [% dest_dir %]/.
 cp [% c('input_files_by_name/macos-x86_64') %]/* [% dest_dir %]/.
 cp [% c('input_files_by_name/macos-aarch64') %]/* [% dest_dir %]/.
 cp [% c('input_files_by_name/windows-i686') %]/* [% dest_dir %]/.

--- a/projects/release/config
+++ b/projects/release/config
@@ -30,6 +30,12 @@ input_files:
    target_append:
     - linux
     - linux-x86_64
+ - name: linux-aarch64
+   project: package
+   target_append:
+    - linux-cross
+    - linux
+    - linux-aarch64
  # macos
  - name: macos-x86_64
    project: package

--- a/projects/ricochet-refresh/build
+++ b/projects/ricochet-refresh/build
@@ -80,6 +80,10 @@ popd
   export PKG_CONFIG_LIBDIR=$sysrootdir/lib/pkgconfig
 [% END -%]
 
+[% IF c("var/linux-cross") -%]
+  export PKG_CONFIG_LIBDIR="/usr/lib/[% c("var/compiler_target") %]/pkgconfig:/usr/share/pkgconfig"
+[% END -%]
+
 CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=MinSizeRel
                 -DFORCE_QT5=ON
                 -DProtobuf_USE_STATIC_LIBS=ON
@@ -95,6 +99,9 @@ CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=MinSizeRel
 # Set toolchain file
 [% IF c("var/linux-i686") -%]
     CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=../src/cmake/toolchains/i386-linux-gnu.cmake $CMAKE_FLAGS"
+[% END -%]
+[% IF c("var/linux-cross") -%]
+    CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=[% c("var/arch") %] $CMAKE_FLAGS"
 [% END -%]
 [% IF c("var/windows") -%]
     CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Windows $CMAKE_FLAGS"

--- a/projects/ricochet-refresh/config
+++ b/projects/ricochet-refresh/config
@@ -65,6 +65,34 @@ targets:
         - libxi-dev
         - libxkbcommon-x11-dev
         - libc6-dev
+  linux-aarch64:
+    var:
+      pluggable_transports: 0
+      arch_deps:
+        - libfontconfig1-dev:arm64
+        - libfreetype6-dev:arm64
+        - libxkbcommon-dev:arm64
+        - libxcb-glx0-dev:arm64
+        - libxcb-keysyms1-dev:arm64
+        - libxcb-image0-dev:arm64
+        - libxcb-shm0-dev:arm64
+        - libxcb-icccm4-dev:arm64
+        - libxcb-sync0-dev:arm64
+        - libxcb-xfixes0-dev:arm64
+        - libxcb-shape0-dev:arm64
+        - libxcb-randr0-dev:arm64
+        - libxcb-render-util0-dev:arm64
+        - libxcb-xinerama0-dev:arm64
+        - libx11-xcb-dev:arm64
+        - libglu1-mesa-dev:arm64
+        - libxrender-dev:arm64
+        - libxi-dev:arm64
+        - libxkbcommon-x11-dev:arm64
+        - libc6-dev:arm64
+        # linked to by libxdmcp, which is linked by libxcb
+        - libbsd-dev:arm64
+        # linked to by libxcb-image
+        - libxcb-util-dev:arm64
 
 input_files:
   - project: container-image

--- a/projects/toolchain-linux-cross-gcc/build
+++ b/projects/toolchain-linux-cross-gcc/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+
+# passthrough for gcc
+mv [% c("input_files_by_name/gcc-cross") %] '[% dest_dir %]/[% c("filename") %]'

--- a/projects/toolchain-linux-cross-gcc/config
+++ b/projects/toolchain-linux-cross-gcc/config
@@ -1,0 +1,22 @@
+# vim: filetype=yaml sw=2
+filename: '[% project %]-[% c("version") %]-[% c("var/arch") %]-[% c("var/build_id") %].tar.gz'
+version: '[% pc("gcc", "version") %]'
+container:
+  use_container: 1
+
+var:
+  setup: |
+    mkdir -p $distdir
+    tar -C $distdir -xf $rootdir/[% c("build_toolchain_tarfile") %]
+    export PATH="$distdir/gcc/bin:$PATH"
+    export LD_LIBRARY_PATH=$distdir/gcc/[% c("var/compiler_target") %]/lib64:$distdir/gcc/lib64:$distdir/gcc/lib32
+    export CC="$distdir/gcc/bin/[% c("var/arch") %]-linux-gnu-gcc"
+    export CXX="$distdir/gcc/bin/[% c("var/arch") %]-linux-gnu-g++"
+    export CFLAGS='[% c("var/CFLAGS") %]'
+    export CXXFLAGS='[% c("var/CXXFLAGS") %]'
+    export LDFLAGS='[% c("var/LDFLAGS") %]'
+
+input_files:
+  - project: container-image
+  - name: gcc-cross
+    project: gcc-cross

--- a/projects/zlib/build
+++ b/projects/zlib/build
@@ -18,6 +18,9 @@ cd $builddir/[% project %]-[% c('version') %]
   [% IF c("var/linux") %]
     export CC='gcc [% c("var/CFLAGS") %]'
   [% END -%]
+  [% IF c("var/linux-cross") %]
+    export CC="[% c("var/compiler_target") %]-$CC"
+  [% END -%]
 
   export CHOST=[% c("var/chost") %]
   export AR=[% c("var/ar") %]

--- a/projects/zlib/config
+++ b/projects/zlib/config
@@ -14,6 +14,11 @@ targets:
       chost: x86_64-pc-linux-gnu
       ar: $distdir/gcc/bin/x86_64-pc-linux-gnu-gcc-ar
       ranlib: $distdir/gcc/bin/x86_64-pc-linux-gnu-gcc-ranlib
+  linux-cross:
+    var:
+      chost: '[% c("var/compiler_target") %]'
+      ar: '$distdir/gcc/bin/[% c("var/compiler_target") %]-gcc-ar'
+      ranlib: '$distdir/gcc/bin/[% c("var/compiler_target") %]-gcc-ranlib'
   macos:
     var:
       chost: '[% c("var/compiler_target") %]'

--- a/rbm.conf
+++ b/rbm.conf
@@ -56,6 +56,8 @@ var:
     # updating the gcc version will update the ABI requirements on libstdc++ on Linux
     # see: https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
     gcc: 10.5.0
+    glibc: 2.31
+    linux: 5.10.216
     llvm-project: 16.0.4
     mingw-w64: 11.0.0
     binutils: '2.39'
@@ -118,6 +120,7 @@ targets:
     var:
       arch: x86_64
       linux-x86_64: 1
+      linux-cross: 0
       CFLAGS: -fPIC
       CXXFLAGS: -fPIC
       LDFLAGS:
@@ -130,9 +133,25 @@ targets:
         - lib32stdc++6
         - libc6-dev-i386
       linux-i686: 1
+      linux-cross: 0
       CFLAGS: -m32
       CXXFLAGS: -m32
       LDFLAGS: -m32
+  linux-aarch64:
+    var:
+      arch: aarch64
+      arch_debian: arm64
+      linux-aarch64: 1
+      linux-cross: 1
+      CFLAGS: -fPIC
+      CXXFLAGS: -fPIC
+      LDFLAGS:
+  linux-cross:
+    var:
+      linux-cross: 1
+      add_architecture: 1
+      build-toolchain: 'toolchain-linux-cross-gcc'
+      compiler_target: '[% c("var/arch") %]-linux-gnu'
   # macOS targets
   macos:
     var:


### PR DESCRIPTION
This PR adds support for linux-aarch64 to Ricochet Refresh. The gcc cross-toolchain used to build from x86_64 is adapted from [tor-browser-build](https://gitlab.torproject.org/tpo/applications/tor-browser-build). This PR is marked as a draft since:

- it embeds an unreleased build of `tor-expert-bundle` which must be replaced with an official linux-aarch64 release when available
- no AppImage is created since `linuxdeploy` does not support cross-compilation; a choice needs to be made on whether not to provide linux-aarch64 AppImages or to build them using virtualization (more specifically, emulation), e.g. via `rbm`+`binfmt-misc` (virtualizing the whole build succeeds, so it shouldn't be too difficult to factor out AppImage building into a separate virtualized project)
- in order to build `qt` I had to write a large-ish patch to avoid linking issues. That's not very maintainable (`qt` upgrades may or may not require significant refreshes if the library dependencies change), so if anyone comes up with a better solution I'd be happier

Note: the patchset is applied to the last released tag, not to current main.