### PR TITLE
Replace linux_cross with add_architecture

### DIFF
--- a/projects/cmake-build/config
+++ b/projects/cmake-build/config
@@ -8,8 +8,5 @@ gpg_keyring: cmake.gpg
 container:
   use_container: 1
 
-var:
-  linux_cross: 0
-
 input_files:
   - project: container-image

--- a/projects/container-image/config
+++ b/projects/container-image/config
@@ -21,7 +21,7 @@ pre: |
   export DEBIAN_FRONTEND=noninteractive
   # Update the package cache so the container installs the most recent
   # version of required packages.
-  [% IF c("var/linux_cross") %]
+  [% IF pc(c('origin_project'), 'var/add_architecture', { step => c('origin_step') }) %]
     # Add cross-compilation dpkg architecture
     dpkg --add-architecture [% c("var/arch_debian") %]
   [% END -%]

--- a/projects/linuxdeploy/config
+++ b/projects/linuxdeploy/config
@@ -3,9 +3,6 @@ version: '[% c("var/versions/linuxdeploy") %]'
 container:
   use_container: 1
 
-var:
-  linux_cross: 1
-
 targets:
   linux-x86_64:
     var:

--- a/rbm.conf
+++ b/rbm.conf
@@ -125,11 +125,11 @@ targets:
     var:
       arch: i686
       arch_debian: i386
+      add_architecture: 1
       arch_deps:
         - lib32stdc++6
         - libc6-dev-i386
       linux-i686: 1
-      linux_cross: 1
       CFLAGS: -m32
       CXXFLAGS: -m32
       LDFLAGS: -m32


### PR DESCRIPTION
As described in PR #19, this PR eliminates `linux_cross` (currently unused in reality) in favor of an `add_architecture` variable, better named to explain its purpose and implemented correctly.